### PR TITLE
Trigger builds on only updated branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://aircover.co/badges/drone-plugins/drone-dockerhub/coverage.svg)](https://aircover.co/drone-plugins/drone-dockerhub)
 [![](https://badge.imagelayers.io/plugins/drone-dockerhub:latest.svg)](https://imagelayers.io/?images=plugins/drone-dockerhub:latest 'Get your own badge on imagelayers.io')
 
-Drone plugin to trigger a DockerHub remote build
+Drone plugin to trigger a DockerHub remote build on the updated branch.
 
 ## Binary
 
@@ -35,7 +35,7 @@ make deps build
         "finished_at": 1421029813,
         "message": "Update the Readme",
         "author": "johnsmith",
-        "author_email": "john.smith@gmail.com"
+        "author_email": "john.smith@gmail.com",
         "event": "push",
         "branch": "master",
         "commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
@@ -82,7 +82,7 @@ docker run -i plugins/drone-dockerhub <<EOF
         "finished_at": 1421029813,
         "message": "Update the Readme",
         "author": "johnsmith",
-        "author_email": "john.smith@gmail.com"
+        "author_email": "john.smith@gmail.com",
         "event": "push",
         "branch": "master",
         "commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",

--- a/main.go
+++ b/main.go
@@ -24,15 +24,18 @@ func main() {
 	fmt.Printf("Drone DockerHub Plugin built at %s\n", buildDate)
 
 	vargs := DockerHub{}
+	build := plugin.Build{}
 
 	plugin.Param("vargs", &vargs)
+	plugin.Param("build", &build)
+
 	if err := plugin.Parse(); err != nil {
 		println(err.Error())
 		os.Exit(1)
 	}
 
 	endpoint := fmt.Sprintf("https://registry.hub.docker.com/u/%s/trigger/%s/", vargs.Repo, vargs.Token)
-	values := url.Values{"build": {"true"}}
+	values := url.Values{"source_type": {"Branch"}, "source_name": {build.Branch}}
 
 	var resp *http.Response
 	err := try.Do(func(attempt int) (bool, error) {

--- a/main.go
+++ b/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
-	"os"
-	"regexp"
-
 	"github.com/drone/drone-plugin-go/plugin"
 	try "gopkg.in/matryer/try.v1"
+	"net/http"
+	"os"
+	"regexp"
 )
 
 type DockerHub struct {
@@ -16,9 +16,16 @@ type DockerHub struct {
 	Repo  string `json:"repo"`
 }
 
+type DockerHubValues struct {
+	SourceType string `json:"source_type"`
+	SourceName string `json:"source_name"`
+}
+
 var (
 	buildDate string
 )
+
+var re = regexp.MustCompile("(.*?/trigger/)[^/]+")
 
 func main() {
 	fmt.Printf("Drone DockerHub Plugin built at %s\n", buildDate)
@@ -35,18 +42,29 @@ func main() {
 	}
 
 	endpoint := fmt.Sprintf("https://registry.hub.docker.com/u/%s/trigger/%s/", vargs.Repo, vargs.Token)
-	values := url.Values{"source_type": {"Branch"}, "source_name": {build.Branch}}
+	values := DockerHubValues{SourceType: "Branch", SourceName: build.Branch}
+	values_json, err := json.Marshal(values)
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(values_json))
+
+	if err != nil {
+		fmt.Println(re.ReplaceAllString(err.Error(), "${1}HIDDEN"))
+
+		os.Exit(1)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
 
 	var resp *http.Response
-	err := try.Do(func(attempt int) (bool, error) {
+	err = try.Do(func(attempt int) (bool, error) {
 		var err error
 
-		resp, err = http.PostForm(endpoint, values)
+		resp, err = client.Do(req)
 		return attempt < 5, err
 	})
 
 	if err != nil {
-		re := regexp.MustCompile("(.*?/trigger/)[^/]+")
 		fmt.Println(re.ReplaceAllString(err.Error(), "${1}HIDDEN"))
 
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/drone/drone-plugin-go/plugin"
-	try "gopkg.in/matryer/try.v1"
 	"net/http"
 	"os"
 	"regexp"
+
+	"github.com/drone/drone-plugin-go/plugin"
+	try "gopkg.in/matryer/try.v1"
 )
 
 type DockerHub struct {


### PR DESCRIPTION
Current implementation triggers docker hub to rebuild all branches.  Besides being unnecessary, it is also unhelpful if you have linked a redeploy to an image rebuild.  It's not ideal to have a redeploy of production when it's only a development branch that had any code changes.

This pull request changes the plugin to only trigger a rebuild on the updated branch.
